### PR TITLE
Return data as dict in from get_repo and get_dev functions

### DIFF
--- a/githubtrending/trending.py
+++ b/githubtrending/trending.py
@@ -131,6 +131,10 @@ def get_trending_devs(**kwargs):
         dev_repo_names = get_trending_dev_repo_names(tree)
         dev_repo_desc = get_trending_dev_repo_desc(tree)
         devs = list(zip(dev_names, dev_repo_names, dev_repo_desc))
+        devs = [{'dev_name':dev_name,
+                 'repo_name': repo_name,
+                 'description': description}
+                for dev_name, repo_name, description in devs]
     return devs
 
 

--- a/githubtrending/trending.py
+++ b/githubtrending/trending.py
@@ -87,6 +87,11 @@ def get_trending_repos(**kwargs):
         repo_meta = get_trending_repo_meta(tree)
         repo_stars_and_languages = get_trending_repo_stars_and_languages(repo_meta)
         repos = list(zip(repo_names, repo_desc, repo_stars_and_languages))
+        repos = [{'repo_name': repo_name,
+                  'description': description,
+                  'stars': stars,
+                  'language': lang}
+                 for repo_name, description, [stars, lang] in repos]
     return repos
 
 

--- a/githubtrending/trending.py
+++ b/githubtrending/trending.py
@@ -131,7 +131,7 @@ def get_trending_devs(**kwargs):
         dev_repo_names = get_trending_dev_repo_names(tree)
         dev_repo_desc = get_trending_dev_repo_desc(tree)
         devs = list(zip(dev_names, dev_repo_names, dev_repo_desc))
-        devs = [{'dev_name':dev_name,
+        devs = [{'dev_name': dev_name,
                  'repo_name': repo_name,
                  'description': description}
                 for dev_name, repo_name, description in devs]

--- a/githubtrending/utils.py
+++ b/githubtrending/utils.py
@@ -13,7 +13,9 @@ def get_console_size():
 def get_print_size_for_repo(data):
     name, lang, star = [0]*3
     for each in data:
-        repo_name, desc, [stars, language] = each
+        repo_name = each.get('repo_name')
+        stars = each.get('stars')
+        language = each.get('language')
         name = max(len(repo_name), name)
         lang = max(len(language), lang)
         star = max(len(stars), star)

--- a/githubtrending/utils.py
+++ b/githubtrending/utils.py
@@ -31,7 +31,8 @@ def get_print_size_for_repo(data):
 def get_print_size_for_dev(data):
     dev, repo = [0]*2
     for each in data:
-        dev_name, repo_name, description = each
+        dev_name = each.get('dev_name')
+        repo_name = each.get('repo_name')
         dev = max(len(dev_name), dev)
         repo = max(len(repo_name), repo)
 

--- a/githubtrending/writers.py
+++ b/githubtrending/writers.py
@@ -80,7 +80,9 @@ def print_trending_devs(data):
 
     for idx, each in enumerate(data):
         click.echo()
-        dev_name, repo_name, description = each
+        dev_name = each.get('dev_name')
+        repo_name = each.get('repo_name')
+        description = each.get('description')
         click.secho(
             "%*s" % (print_size["IDX"], str(idx+1)),
             nl=False, bold=True, fg=COLOR['IDX'])

--- a/githubtrending/writers.py
+++ b/githubtrending/writers.py
@@ -48,7 +48,10 @@ def print_trending_repos(data):
     print_headers(print_size)
 
     for idx, each in enumerate(data):
-        repo_name, description, [stars, language] = each
+        repo_name = each.get('repo_name')
+        description = each.get('description')
+        stars = each.get('stars')
+        language = each.get('language')
         click.echo()
         click.secho(
             "%*s" % (print_size["IDX"], str(idx+1)),


### PR DESCRIPTION
This PR updates _get_trending_repos()_ and _get_trending_devs()_ to return list of dict instead of list of tuples. Also It updates the corresponding functions in _writers.py_ and _utils.py_
